### PR TITLE
Add support for old browsers and node, fixes #2

### DIFF
--- a/src/driver.js
+++ b/src/driver.js
@@ -1,6 +1,7 @@
 import Rx from 'rx';
 
 import now from 'performance-now';
+import requestAnimationFrame from 'raf';
 
 function makeAnimationDriver () {
   return function animationDriver () {

--- a/test/animation-driver-test.js
+++ b/test/animation-driver-test.js
@@ -3,11 +3,7 @@
 import Rx from 'rx';
 import {makeAnimationDriver} from '../src/driver';
 
-import raf from 'raf';
-
 import assert from 'assert';
-
-global.requestAnimationFrame = raf;
 
 describe('Animation driver', () => {
   it('provides an observable of requestAnimationFrame events', (done) => {


### PR DESCRIPTION
Old browsers don't support requestAnimationFrame (or have it prefixed)

Using the 'raf' module means I can support them easily!

Yay :D
